### PR TITLE
Add hybrid retrieval and summarization utilities

### DIFF
--- a/backend/app/core/bm25_index.py
+++ b/backend/app/core/bm25_index.py
@@ -1,0 +1,46 @@
+import os, json
+from typing import List, Dict
+from rank_bm25 import BM25Okapi
+from .settings import settings
+
+INDEX_FILE = settings.bm25_index_path
+
+
+def add_chunks(chunks: List[Dict]):
+    """Persist chunks for BM25 search"""
+    os.makedirs(os.path.dirname(INDEX_FILE), exist_ok=True)
+    with open(INDEX_FILE, "a", encoding="utf-8") as f:
+        for c in chunks:
+            f.write(json.dumps(c, ensure_ascii=False) + "\n")
+
+
+def _load_corpus(filter_doc_ids: List[str] | None = None):
+    texts, metas = [], []
+    if not os.path.exists(INDEX_FILE):
+        return texts, metas
+    with open(INDEX_FILE, "r", encoding="utf-8") as f:
+        for line in f:
+            try:
+                obj = json.loads(line)
+            except Exception:
+                continue
+            if filter_doc_ids and obj.get("doc_id") not in filter_doc_ids:
+                continue
+            texts.append(obj.get("text", "").split())
+            metas.append(obj)
+    return texts, metas
+
+
+def bm25_search(query: str, top_k: int = 20, filter_doc_ids: List[str] | None = None):
+    texts, metas = _load_corpus(filter_doc_ids)
+    if not texts:
+        return []
+    bm25 = BM25Okapi(texts)
+    scores = bm25.get_scores(query.split())
+    results = []
+    for meta, score in zip(metas, scores):
+        r = meta.copy()
+        r["score"] = float(score)
+        results.append(r)
+    results.sort(key=lambda x: x["score"], reverse=True)
+    return results[:top_k]

--- a/backend/app/core/embeddings.py
+++ b/backend/app/core/embeddings.py
@@ -1,6 +1,7 @@
 from sentence_transformers import SentenceTransformer
 from qdrant_client import QdrantClient, models
 from .settings import settings
+from .bm25_index import add_chunks
 import numpy as np
 
 _embedder = None
@@ -43,6 +44,7 @@ def upsert_chunks(chunks: list[dict]):
             payload=c
         ))
     qdr.upsert(collection_name=settings.qdrant_collection, points=points)
+    add_chunks(chunks)
 
 
 def dense_search(query: str, top_k: int = 20, filter_doc_ids: list[str] | None = None):

--- a/backend/app/core/search.py
+++ b/backend/app/core/search.py
@@ -1,0 +1,15 @@
+from typing import List
+from .embeddings import dense_search
+from .bm25_index import bm25_search
+from .rerank import bm25_rerank
+
+
+def hybrid_search(query: str, top_k: int = 5, filter_doc_ids: List[str] | None = None):
+    dense = dense_search(query, top_k=top_k * 4, filter_doc_ids=filter_doc_ids)
+    bm25 = bm25_search(query, top_k=top_k * 4, filter_doc_ids=filter_doc_ids)
+    merged = {c["id"]: c for c in dense}
+    for c in bm25:
+        merged.setdefault(c["id"], c)
+    candidates = list(merged.values())
+    ranked = bm25_rerank(query, candidates, top_k=top_k)
+    return ranked

--- a/backend/app/core/settings.py
+++ b/backend/app/core/settings.py
@@ -7,6 +7,10 @@ class Settings(BaseModel):
     upload_dir: str = os.getenv("UPLOAD_DIR", "/data/uploads")
     cache_dir: str = os.getenv("CACHE_DIR", "/data/cache")
 
+    # kalıcı depolar
+    docstore_path: str = os.getenv("DOCSTORE_PATH", "/data/docs.jsonl")
+    bm25_index_path: str = os.getenv("BM25_INDEX_PATH", "/data/chunks.jsonl")
+
     qdrant_url: str = os.getenv("QDRANT_URL", "http://localhost:6333")
     qdrant_collection: str = os.getenv("QDRANT_COLLECTION", "pdf_chunks")
 
@@ -19,3 +23,6 @@ settings = Settings()
 # dizinleri oluştur
 os.makedirs(settings.upload_dir, exist_ok=True)
 os.makedirs(settings.cache_dir, exist_ok=True)
+# dosya yollarının klasörleri
+os.makedirs(os.path.dirname(settings.docstore_path), exist_ok=True)
+os.makedirs(os.path.dirname(settings.bm25_index_path), exist_ok=True)

--- a/backend/app/core/store.py
+++ b/backend/app/core/store.py
@@ -1,7 +1,9 @@
-import os, shutil, uuid
+import os, shutil, uuid, json
 from .settings import settings
 
 UPLOAD_DIR = settings.upload_dir
+
+DOCSTORE = settings.docstore_path
 
 
 def save_upload(file_bytes: bytes, filename: str) -> str:
@@ -11,3 +13,22 @@ def save_upload(file_bytes: bytes, filename: str) -> str:
     with open(path, "wb") as f:
         f.write(file_bytes)
     return path
+
+
+def register_doc(doc_id: str, path: str):
+    with open(DOCSTORE, "a", encoding="utf-8") as f:
+        f.write(json.dumps({"doc_id": doc_id, "path": path}) + "\n")
+
+
+def get_doc_path(doc_id: str) -> str | None:
+    if not os.path.exists(DOCSTORE):
+        return None
+    with open(DOCSTORE, "r", encoding="utf-8") as f:
+        for line in f:
+            try:
+                rec = json.loads(line)
+            except Exception:
+                continue
+            if rec.get("doc_id") == doc_id:
+                return rec.get("path")
+    return None

--- a/backend/app/core/summarizer.py
+++ b/backend/app/core/summarizer.py
@@ -1,0 +1,33 @@
+import json
+from collections import defaultdict
+from typing import Dict
+from .settings import settings
+
+INDEX_FILE = settings.bm25_index_path
+
+
+def summarize_document(doc_id: str) -> Dict:
+    pages = defaultdict(str)
+    try:
+        with open(INDEX_FILE, "r", encoding="utf-8") as f:
+            for line in f:
+                obj = json.loads(line)
+                if obj.get("doc_id") != doc_id:
+                    continue
+                pages[obj["page"]] += " " + obj.get("text", "")
+    except FileNotFoundError:
+        return {"sections": [], "global_summary": ""}
+
+    sections = []
+    all_text = []
+    for page, text in sorted(pages.items()):
+        words = text.strip().split()
+        summary = " ".join(words[:50])
+        sections.append({
+            "pages": str(page),
+            "summary": summary,
+            "citation": {"doc_id": doc_id, "page": page, "chunk_id": f"{doc_id}-{page}-0"},
+        })
+        all_text.extend(words)
+    global_summary = " ".join(all_text[:100])
+    return {"sections": sections, "global_summary": global_summary}

--- a/backend/app/routers/ingest.py
+++ b/backend/app/routers/ingest.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, UploadFile, File, HTTPException
-from ..core.store import save_upload
+from ..core.store import save_upload, register_doc
 from ..core.ocr import run_ocr
 from ..core.layout import extract_pages
 from ..core.chunking import make_chunks
@@ -22,6 +22,7 @@ async def ingest(pdf: UploadFile = File(...), ocr: bool = True):
         except Exception:
             pass  # taranmış değilse sorun çıkmadan devam et
 
+    register_doc(doc_id, path)
     pages = extract_pages(path)
     chunks = make_chunks(doc_id, pages)
     upsert_chunks(chunks)

--- a/backend/app/routers/qa.py
+++ b/backend/app/routers/qa.py
@@ -1,14 +1,12 @@
 from fastapi import APIRouter
 from ..schemas import QARequest, QAReply
-from ..core.embeddings import dense_search
-from ..core.rerank import bm25_rerank
+from ..core.search import hybrid_search
 
 router = APIRouter(prefix="/qa", tags=["qa"])
 
 @router.post("", response_model=QAReply)
 def qa(req: QARequest):
-    candidates = dense_search(req.query, top_k=30, filter_doc_ids=req.doc_ids)
-    top = bm25_rerank(req.query, candidates, top_k=req.top_k)
+    top = hybrid_search(req.query, top_k=req.top_k, filter_doc_ids=req.doc_ids)
 
     # Basit cevap: ilk chunklardan derleyelim (demo)
     answer = (

--- a/backend/app/routers/search.py
+++ b/backend/app/routers/search.py
@@ -1,9 +1,9 @@
 from fastapi import APIRouter
-from ..core.embeddings import dense_search
+from ..core.search import hybrid_search
 
 router = APIRouter(prefix="/search", tags=["search"])
 
 @router.get("")
-def search(q: str, top_k: int = 10):
-    res = dense_search(q, top_k=top_k)
+def search(q: str, top_k: int = 5):
+    res = hybrid_search(q, top_k=top_k)
     return res

--- a/backend/app/routers/summarize.py
+++ b/backend/app/routers/summarize.py
@@ -1,13 +1,10 @@
 from fastapi import APIRouter
 from ..schemas import SummarizeReq
+from ..core.summarizer import summarize_document
 
 router = APIRouter(prefix="/summarize", tags=["summarize"])
 
 @router.post("")
 def summarize(req: SummarizeReq):
-    # Demo: gerçek LLM çağrısı yerine iskelet
-    return {
-        "doc_id": req.doc_id,
-        "level": req.level,
-        "summary": "(demo) Bölüm özetleri + global özet burada üretilecek."
-    }
+    data = summarize_document(req.doc_id)
+    return {"doc_id": req.doc_id, "level": req.level, **data}

--- a/backend/app/routers/tables.py
+++ b/backend/app/routers/tables.py
@@ -1,8 +1,33 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
+from ..core.store import get_doc_path
+import os, pdfplumber
 
 router = APIRouter(prefix="/tables", tags=["tables"])
 
 @router.get("")
 def extract_tables(doc_id: str, pages: str | None = None):
-    # TODO: pdfplumber ile tablo çıkarımı (demo placeholder)
-    return {"doc_id": doc_id, "tables": []}
+    path = get_doc_path(doc_id)
+    if not path or not os.path.exists(path):
+        raise HTTPException(404, "doc_id bulunamadı")
+
+    page_nums = None
+    if pages:
+        page_nums = [int(p.strip()) for p in pages.split(",") if p.strip().isdigit()]
+
+    tables = []
+    with pdfplumber.open(path) as pdf:
+        total = len(pdf.pages)
+        target_pages = page_nums or range(1, total + 1)
+        for pno in target_pages:
+            if pno < 1 or pno > total:
+                continue
+            page = pdf.pages[pno - 1]
+            extracted = page.extract_tables() or []
+            for idx, table in enumerate(extracted):
+                csv = "\n".join([",".join(row) for row in table])
+                tables.append({
+                    "page": pno,
+                    "table_id": f"{doc_id}-{pno}-{idx}",
+                    "csv": csv,
+                })
+    return {"doc_id": doc_id, "tables": tables}


### PR DESCRIPTION
## Summary
- persist uploaded document paths and chunks for BM25 search
- implement hybrid dense+BM25 retrieval with reranking
- add simple summarization and table extraction utilities

## Testing
- `python -m py_compile backend/app/core/settings.py backend/app/core/store.py backend/app/core/bm25_index.py backend/app/core/embeddings.py backend/app/core/search.py backend/app/routers/search.py backend/app/routers/qa.py backend/app/routers/ingest.py backend/app/routers/tables.py backend/app/core/summarizer.py backend/app/routers/summarize.py`


------
https://chatgpt.com/codex/tasks/task_e_68990b116ab483268e1984b8e0ded096